### PR TITLE
Fix duplicate import in plotter

### DIFF
--- a/photometry_tool/plotter.py
+++ b/photometry_tool/plotter.py
@@ -1,6 +1,5 @@
 import matplotlib.pyplot as plt
 from astropy.time import Time
-from collections import defaultdict
 from collections import namedtuple, defaultdict
 from itertools import cycle
 


### PR DESCRIPTION
## Summary
- clean up `plotter` imports

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840da113f448331b1c0e5c96516cc56